### PR TITLE
Add 'babel-preset-env' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"babel-cli": "^6.26.0",
 		"babel-eslint": "^8.0.3",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+		"babel-preset-env": "^1.6.1",
 		"babel-preset-react": "^6.24.1",
 		"babel-preset-stage-3": "^6.24.1",
 		"browser-env": "^3.2.4",
@@ -82,6 +83,7 @@
 			"transform-es2015-modules-commonjs"
 		],
 		"presets": [
+			"env",
 			"react",
 			"stage-3"
 		]


### PR DESCRIPTION
Similar to `react-router-util` [PR#5](https://github.com/sindresorhus/react-router-util/pull/5) , to support transpilation for older browsers.