### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,7 @@ export function getDisplayName(component: React.ComponentClass): string;
 
 export const canUseDOM: boolean;
 
-export class autoBind {
-  static react(el: React.ReactNode, options?: any): React.ReactNode;
-}
+export function autoBind (el: React.ReactNode, options?: any): React.ReactNode;
 
 interface IfProps {
   condition: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+export function classNames(...args: any[]): string;
+
+export function isStatelessComponent(component: React.ComponentClass): boolean;
+
+export function getDisplayName(component: React.ComponentClass): string;
+
+export const canUseDOM: boolean;
+
+export class autoBind {
+  static react(el: React.ReactNode, options?: any): React.ReactNode;
+}
+
+interface IfProps {
+  condition: boolean;
+  children?: React.ReactNode;
+  render?: () => React.ReactNode;
+}
+
+export class If extends React.Component<IfProps> {}
+
+interface ChooseOtherwiseProps {
+  children?: React.ReactNode;
+  render?: () => React.ReactNode;
+}
+
+export class ChooseOtherwise extends React.Component<ChooseOtherwiseProps> {}
+
+export class Choose extends React.Component {
+  static When: typeof If;
+  static Otherwise: typeof ChooseOtherwise;
+}
+
+interface ForProps {
+  of: any[];
+  render?: (item: any, index: number) => React.ReactNode;
+}
+
+export class For extends React.Component<ForProps> {}
+
+interface ElementClassProps {
+  add?: string;
+  remove?: string;
+}
+
+export class RootClass extends React.Component<ElementClassProps> {}
+
+export class BodyClass extends React.Component<ElementClassProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export function getDisplayName(component: React.ComponentClass): string;
 
 export const canUseDOM: boolean;
 
-export function autoBind (el: React.ReactNode, options?: any): React.ReactNode;
+export function autoBind(el: React.ReactNode, options?: any): React.ReactNode;
 
 interface IfProps {
 	condition: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,35 +11,35 @@ export const canUseDOM: boolean;
 export function autoBind (el: React.ReactNode, options?: any): React.ReactNode;
 
 interface IfProps {
-  condition: boolean;
-  children?: React.ReactNode;
-  render?: () => React.ReactNode;
+	condition: boolean;
+	children?: React.ReactNode;
+	render?: () => React.ReactNode;
 }
 
 export class If extends React.Component<IfProps> {}
 
 interface ChooseOtherwiseProps {
-  children?: React.ReactNode;
-  render?: () => React.ReactNode;
+	children?: React.ReactNode;
+	render?: () => React.ReactNode;
 }
 
 export class ChooseOtherwise extends React.Component<ChooseOtherwiseProps> {}
 
 export class Choose extends React.Component {
-  static When: typeof If;
-  static Otherwise: typeof ChooseOtherwise;
+	static When: typeof If;
+	static Otherwise: typeof ChooseOtherwise;
 }
 
 interface ForProps {
-  of: any[];
-  render?: (item: any, index: number) => React.ReactNode;
+	of: any[];
+	render?: (item: any, index: number) => React.ReactNode;
 }
 
 export class For extends React.Component<ForProps> {}
 
 interface ElementClassProps {
-  add?: string;
-  remove?: string;
+	add?: string;
+	remove?: string;
 }
 
 export class RootClass extends React.Component<ElementClassProps> {}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"prepublishOnly": "npm run build"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"./index.d.ts"
 	],
 	"keywords": [
 		"react",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"main": "./dist/index.js",
+	"typings": "./index.d.ts",
 	"engines": {
 		"node": ">=8"
 	},

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"files": [
 		"dist",
-		"./index.d.ts"
+		"index.d.ts"
 	],
 	"keywords": [
 		"react",


### PR DESCRIPTION
Added type definition for use with TypeScript. Without these there is no compile time checking when using TypeScript to build a React application.

Not sure why the unit test fails now with a `7:1  Do not reference the index file directly  unicorn/import-index`. Not something I touched.