### PR TITLE
Fix PropType render of the `<For/>` component to be required

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ Choose.Otherwise.propTypes = {
 export const For = ({render, of}) => of.map((item, index) => render(item, index));
 For.propTypes = {
 	of: PropTypes.array.isRequired,
-	render: PropTypes.func
+	render: PropTypes.func.isRequired
 };
 
 class ElementClass extends React.PureComponent {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"babel-preset-react": "^6.24.1",
 		"babel-preset-stage-3": "^6.24.1",
 		"browser-env": "^3.2.4",
+		"jest-prop-type-error": "^1.1.0",
 		"react": "^16.2.0",
 		"react-dom": "^16.2.0",
 		"react-test-renderer": "^16.2.0",
@@ -74,7 +75,8 @@
 	},
 	"ava": {
 		"require": [
-			"babel-register"
+			"babel-register",
+			"jest-prop-type-error"
 		],
 		"babel": "inherit"
 	},

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,15 @@ test('<For>', t => {
 	snapshotJSX(t, <For of={['🌈', '🦄', '😎']} render={(item, index) =>
 		<button key={index}>{item}</button>
 	}/>);
+
+	const error = t.throws(() => snapshotJSX(t, <For of={['🌈', '🦄', '😎']}/>), Error);
+	error.message = error.message.replace(/(\n|\r| +(?= ))/g, '');
+
+	const expectedErrorMessage = (
+		'Warning: Failed prop type: The prop `render` is marked as required ' +
+		'in `For`, but its value is `undefined`. in For'
+	);
+	t.is(error.message, expectedErrorMessage);
 });
 
 test('<RootClass/>', t => {


### PR DESCRIPTION
Fixes #9

I wanted to check in the tests to ensure if the user does not pass a `render` prop, it will show an error. But as the `console` of the application is active, when the verification ran, the warning message was appearing on the tests screen, as you can see in the following image:
![console_message](https://user-images.githubusercontent.com/8882260/41811094-5c3998c8-76df-11e8-8736-99a832a53fa6.png)


To solve that, I used a lib called [jest-prop-type-error](https://www.npmjs.com/package/jest-prop-type-error), that only for tests, it throws an error for props that weren't passed. That way, the test breaks instead of just logging a warning.