### PR TITLE
Add docs to types and add type tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,59 +1,352 @@
-import * as React from 'react';
+import {Component as ReactComponent, ComponentClass, HTMLProps, ReactNode} from 'react';
 
 interface AutoBindOptions {
-	include?: Array<string | RegExp>
-	exclude?: Array<string | RegExp>
+	/**
+	Bind only the given methods.
+	*/
+	readonly include?: ReadonlyArray<string | RegExp>;
+
+	/**
+	Bind methods except for the given methods.
+	*/
+	readonly exclude?: ReadonlyArray<string | RegExp>;
 }
 
-export function autoBind(element: React.ReactNode, options?: AutoBindOptions): React.ReactNode;
+/**
+Automatically binds your `Component` subclass methods to the instance.
 
-export function classNames(...args: Array<string | {[key: string]: unknown}>): string;
+@see https://github.com/sindresorhus/auto-bind#autobindreactself-options
 
-export function isStatelessComponent(component: React.ComponentClass): boolean;
+@param self - Object with methods to bind.
 
-export function getDisplayName(component: React.ComponentClass): string;
+@example
+```
+import autoBind = require('auto-bind');
+class Foo extends Component {
+	constructor(props) {
+		super(props);
+		autoBind.react(this);
+	}
+	// …
+}
+```
+*/
+export function autoBind<T extends ReactNode>(
+	self: T,
+	options?: AutoBindOptions
+): T;
 
+/**
+Conditionally join CSS class names together.
+
+@param input - Accepts a combination of strings and objects. Only object keys with truthy values are included. Anything else is ignored.
+
+@example
+```
+classNames('unicorn', 'rainbow');
+//=> 'unicorn rainbow'
+
+classNames({awesome: true, foo: false}, 'unicorn', {rainbow: false});
+//=> 'awesome unicorn'
+
+classNames('unicorn', null, undefined, 0, 1, {foo: null});
+//=> 'unicorn'
+
+const buttonType = 'main';
+classNames({[`button-${buttonType}`]: true});
+//=> 'button-main'
+```
+
+@example
+```
+const Button = props => {
+	const buttonClass = classNames(
+		'button',
+		{
+			[`button-${props.type}`]: props.type,
+			'button-block': props.block,
+			'button-small': props.small
+		}
+	);
+
+	console.log(buttonClass);
+	//=> 'button button-success button-small'
+
+	return <button className={buttonClass}>…</button>;
+};
+```
+*/
+export function classNames(...input: Array<string | {[className: string]: unknown}>): string;
+
+/**
+Returns a boolean of whether the given `Component` is a functional stateless component.
+
+@see https://javascriptplayground.com/functional-stateless-components-react/
+*/
+export function isStatelessComponent(component: ComponentClass): boolean;
+
+/**
+Returns the display name of the given `Component`.
+
+@see https://reactjs.org/docs/react-component.html#displayname
+*/
+export function getDisplayName(component: ComponentClass): string;
+
+/**
+A boolean of whether you're running in a context with a DOM.
+
+Can be used to check if your component is running in the browser or if it's being server-rendered.
+
+@see https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction
+*/
 export const canUseDOM: boolean;
 
 interface IfProps {
-	condition: boolean;
-	children?: React.ReactNode;
-	render?: () => React.ReactNode;
+	/**
+	Condition to check. Children are only rendered if `true`.
+	*/
+	readonly condition: boolean;
+
+	/**
+	Children to render if `condition` is `true`.
+	*/
+	readonly children?: ReactNode;
+
+	/**
+	If you need the children to not be evaluated when `condition` is `false`, pass a function to the `render` prop that returns the children.
+	*/
+	readonly render?: () => ReactNode;
 }
 
-export class If extends React.Component<IfProps> {}
+/**
+React component that renders the children if the `condition` prop is `true`.
+
+Beware that even though the children are not rendered when the `condition` is `false`, they're still evaluated.
+
+If you need it to not be evaluated on `false`, you can pass a function to the `render` prop that returns the children:
+
+@example
+```
+<div>
+	<If condition={props.error} render={() => (
+		<h1>{props.error}</h1>
+	)}/>
+</div>
+```
+
+Or you could just use plain JavaScript:
+
+@example
+```
+<div>
+	{props.error && (
+		<h1>{props.error}</h1>
+	)}
+</div>
+```
+*/
+export class If extends ReactComponent<IfProps> {}
 
 interface ChooseOtherwiseProps {
-	children?: React.ReactNode;
-	render?: () => React.ReactNode;
+	/**
+	Children to render in the default case.
+	*/
+	readonly children?: ReactNode;
+
+	/**
+	If you need the children to not be evaluated when a `<Condition.When>` component has a true condition, pass a function to the `render` prop that returns the children.
+	*/
+	readonly render?: () => ReactNode;
 }
 
-export class ChooseOtherwise extends React.Component<ChooseOtherwiseProps> {}
+export class ChooseOtherwise extends ReactComponent<ChooseOtherwiseProps> {}
 
-export class Choose extends React.Component {
+/**
+React component similar to a switch case. `<Choose>` has 2 children components:
+
+- `<Choose.When>` that renders the children if the `condition` prop is `true`.
+- `<Choose.Otherwise>` that renders the children if has no `<Choose.When>` with `true` prop `condition`.
+
+Note that even when the children are not rendered, they're still evaluated.
+
+@example
+```
+<div>
+	<Choose>
+		<Choose.When condition={props.success}>
+			<h1>{props.success}</h1>
+		</Choose.When>
+		<Choose.When condition={props.error}>
+			<h1>{props.error}</h1>
+		</Choose.When>
+		<Choose.Otherwise>
+			<h1>😎</h1>
+		</Choose.Otherwise>
+	</Choose>
+</div>
+```
+
+@example
+```
+<div>
+	{(() => {
+		if (props.success) {
+			return <h1>{props.success}</h1>;
+		}
+
+		if (props.error) {
+			return <h1>{props.error}</h1>;
+		}
+
+		return <h1>😎</h1>;
+	})()}
+</div>
+```
+*/
+export class Choose extends ReactComponent {
+	/**
+	Renders the children if the `condition` prop is `true`.
+
+	Use with `Choose` and `Choose.Otherwise`.
+	*/
 	static When: typeof If;
+
+	/**
+	Renders the children if there is no `<Choose.When>` with `true` prop `condition`.
+
+	Use with `Choose` and `Choose.When`.
+	*/
 	static Otherwise: typeof ChooseOtherwise;
 }
 
-interface ForProps {
-	of: unknown[];
-	render?: (item: unknown, index: number) => React.ReactNode;
+interface ForProps<T = unknown> {
+	/**
+	Items to iterate over. `render` will be called once per item.
+	*/
+	readonly of: readonly T[];
+
+	/**
+	Returns the element to render corresponding to an `item`.
+	*/
+	readonly render?: (item: T, index: number) => ReactNode;
 }
 
-export class For extends React.Component<ForProps> {}
+/**
+React component that iterates over the `of` prop and renders the `render` prop.
 
-interface ImageProps extends React.HTMLProps<HTMLImageElement> {
-	url: string;
-	fallbackUrl: string;
+@example
+```
+<div>
+	<For of={['🌈', '🦄', '😎']} render={(item, index) =>
+		<button key={index}>{item}</button>
+	}/>
+</div>
+```
+
+Or you could just use plain JavaScript:
+
+@example
+```
+<div>
+	{['🌈', '🦄', '😎'].map((item, index) =>
+		<button key={index}>{item}</button>
+	)}
+</div>
+```
+*/
+export class For<T = unknown> extends ReactComponent<ForProps<T>> {}
+
+interface ImageProps extends HTMLProps<HTMLImageElement> {
+	/**
+	URL of the image. Use instead of `src`.
+	*/
+	readonly url: string;
+
+	/**
+	Fallback URL to display if the image does not load.
+
+	Default: Hide the image if it fails to load.
+	*/
+	readonly fallbackUrl?: string;
 }
 
-export class Image extends React.Component<ImageProps> {}
+/**
+React component that improves the `<img>` element.
+
+It makes the image invisible if it fails to load instead of showing the default broken image icon. Optionally, specify a fallback image URL.
+
+@example
+```
+<Image
+	url="https://sindresorhus.com/unicorn.jpg"
+	fallbackUrl="https://sindresorhus.com/rainbow.jpg"
+/>
+```
+
+It supports all the props that `<img>` supports, but you use the prop `url` instead of `src`.
+*/
+export class Image extends ReactComponent<ImageProps> {}
 
 interface ElementClassProps {
-	add?: string;
-	remove?: string;
+	/**
+	Classes to add to the root element.
+
+	Either a single class or multiple classes separated by space.
+	*/
+	readonly add?: string;
+
+	/**
+	Classes to remove from the root element.
+
+	Either a single class or multiple classes separated by space.
+	*/
+	readonly remove?: string;
 }
 
-export class RootClass extends React.Component<ElementClassProps> {}
+/**
+Renderless React component that can add and remove classes to the root `<html>` element. It accepts an `add` prop for adding classes, and a `remove` prop for removing classes. Both accept either a single class or multiple classes separated by space.
 
-export class BodyClass extends React.Component<ElementClassProps> {}
+@example
+```
+<If condition={props.isDarkMode}>
+	<RootClass add="dark-mode"/>
+</If>
+```
+
+@example
+```
+<RootClass add="logged-in paid-user" remove="promo"/>
+```
+*/
+export class RootClass extends ReactComponent<ElementClassProps> {}
+
+/**
+Same as `<RootClass/>` but for `<body>`.
+
+Prefer `<RootClass/>` though, because it's nicer to put global classes on `<html>` as you can consistently prefix everything with the class:
+
+@example
+```css
+.dark-mode body {
+	background: #000;
+}
+
+.dark-mode a {
+	…
+}
+```
+
+With `<BodyClass/>` you need to do:
+
+@example
+```css
+body.dark-mode {
+	background: #000;
+}
+
+.dark-mode a {
+	…
+}
+```
+*/
+export class BodyClass extends ReactComponent<ElementClassProps> {}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,0 @@
-import {expectType} from 'tsd-check';
-import {classNames} from '.';
-
-expectType<string>(classNames('foo', {bar: true}));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"scripts": {
 		"build": "babel 'source/*.js' --out-dir=dist",
-		"test": "xo && ava && tsd-check",
+		"test": "xo && ava && tsd",
 		"prepublishOnly": "npm run build"
 	},
 	"files": [
@@ -42,6 +42,7 @@
 		"classes"
 	],
 	"dependencies": {
+		"@types/react": "^16.9.2",
 		"prop-types": "^15.6.2"
 	},
 	"devDependencies": {
@@ -58,7 +59,7 @@
 		"react": "^16.7.0",
 		"react-dom": "^16.7.0",
 		"react-test-renderer": "^16.7.0",
-		"tsd-check": "^0.3.0",
+		"tsd": "^0.7.4",
 		"xo": "^0.23.0"
 	},
 	"peerDependencies": {

--- a/test-d/index.test-d.tsx
+++ b/test-d/index.test-d.tsx
@@ -1,0 +1,86 @@
+import {expectType} from 'tsd';
+import React, {Component as ReactComponent} from 'react';
+import {
+	autoBind,
+	classNames,
+	isStatelessComponent,
+	getDisplayName,
+	canUseDOM,
+	If,
+	Choose,
+	For,
+	Image,
+	RootClass,
+	BodyClass
+} from '..';
+
+class Bar extends ReactComponent {
+	constructor(props: object) {
+		super(props);
+
+		expectType<Bar>(autoBind(this));
+		expectType<Bar>(autoBind(this, { include: ['foo', /bar/] }));
+		expectType<Bar>(autoBind(this, { exclude: ['foo', /bar/] }));
+	}
+}
+
+expectType<string>(classNames('foo', {bar: true}));
+
+expectType<boolean>(isStatelessComponent(Bar));
+
+expectType<string>(getDisplayName(Bar));
+
+expectType<boolean>(canUseDOM);
+
+const IfTest = (props: {error: boolean}) => (
+	<div>
+		<If condition={props.error} render={() => (
+			<h1>{props.error}</h1>
+		)}/>
+	</div>
+)
+
+const ForTest = (
+	<div>
+		<For
+			of={['🌈', '🦄', '😎']}
+			render={(item, index) => <button key={index}>{item}</button>}
+		/>
+	</div>
+);
+
+const ChooseTest = (props: {success: boolean, error: boolean}) => (
+	<div>
+		<Choose>
+			<Choose.When condition={props.success}>
+				<h1>{props.success}</h1>
+			</Choose.When>
+			<Choose.When condition={props.error}>
+				<h1>{props.error}</h1>
+			</Choose.When>
+			<Choose.Otherwise>
+				<h1>😎</h1>
+			</Choose.Otherwise>
+		</Choose>
+	</div>
+);
+
+const ImageTest = (
+	<Image
+		url="https://sindresorhus.com/unicorn.jpg"
+		fallbackUrl="https://sindresorhus.com/rainbow.jpg"
+	/>
+);
+
+const ImageTestNoFallback = (
+	<Image url="https://sindresorhus.com/unicorn.jpg" />
+);
+
+const RootTest = (props: { isDarkMode: boolean }) => (
+	<If condition={props.isDarkMode}>
+		<RootClass add="dark-mode" />
+		<RootClass add="logged-in paid-user" remove="promo" />
+		<BodyClass remove="dark-mode" />
+		<BodyClass add="logged-in paid-user" remove="promo" />
+	</If>
+);


### PR DESCRIPTION
The examples and docs are largely copied from the README 😄

Fixes #11


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11: Add documentation comments and tests for the TypeScript definition](https://issuehunt.io/repos/117923759/issues/11)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->